### PR TITLE
BUG: drop redundant mean of random effects, use exp(std) for scale

### DIFF
--- a/statsmodels/discrete/example_mxlogit.py
+++ b/statsmodels/discrete/example_mxlogit.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
                           name_intercept = name_intercept)
 
     # Fit model
-#    mxlogit_res = mxlogit_mod.fit(method = "bfgs", disp = 1)
+    mxlogit_res = mxlogit_mod.fit(method = "bfgs", disp = 1)
 #    print mxlogit_res.params
 #    print mxlogit_res.llf
 


### PR DESCRIPTION
initial version of 2 fixes for 
- overparameterized means of random effects
- enforce positive scale of random effects variance using exp instead of hard lower bound

see #2382 for details and more